### PR TITLE
vm: Rename 'jump*' to 'hop*'

### DIFF
--- a/module/arch-chip/src/OP_SE_REG_CON.ts
+++ b/module/arch-chip/src/OP_SE_REG_CON.ts
@@ -34,7 +34,7 @@ export default class OP_SE_REG_CON extends Op<ChipArchitecture> {
 
 	public execute(this: void, context: Context<ChipArchitecture>, p1: OpCode, p2: OpCode): void {
 		if (context.register_data[p1] === p2) {
-			context.jumpForwards(2);
+			context.hopForwards(2);
 		}
 	}
 }

--- a/module/arch-chip/src/OP_SE_REG_REG.ts
+++ b/module/arch-chip/src/OP_SE_REG_REG.ts
@@ -34,7 +34,7 @@ export default class OP_SE_REG_REG extends Op<ChipArchitecture> {
 
 	public execute(this: void, context: Context<ChipArchitecture>, p1: OpCode, p2: OpCode): void {
 		if (context.register_data[p1] === context.register_data[p2]) {
-			context.jumpForwards(2);
+			context.hopForwards(2);
 		}
 	}
 }

--- a/module/arch-chip/src/OP_SNE_REG_CON.ts
+++ b/module/arch-chip/src/OP_SNE_REG_CON.ts
@@ -34,7 +34,7 @@ export default class OP_SNE_REG_CON extends Op<ChipArchitecture> {
 
 	public execute(this: void, context: Context<ChipArchitecture>, p1: OpCode, p2: OpCode): void {
 		if (context.register_data[p1] !== p2) {
-			context.jumpForwards(2);
+			context.hopForwards(2);
 		}
 	}
 }

--- a/module/arch-chip/src/OP_SNE_REG_REG.ts
+++ b/module/arch-chip/src/OP_SNE_REG_REG.ts
@@ -34,7 +34,7 @@ export default class OP_SNE_REG_REG extends Op<ChipArchitecture> {
 
 	public execute(this: void, context: Context<ChipArchitecture>, p1: OpCode, p2: OpCode): void {
 		if (context.register_data[p1] !== context.register_data[p2]) {
-			context.jumpForwards(2);
+			context.hopBackwards(2);
 		}
 	}
 }

--- a/module/vm/src/VM.ts
+++ b/module/vm/src/VM.ts
@@ -101,33 +101,41 @@ export class VMBase<A> {
 	// -------------------------------------------------------------------------------------------------------------
 
 	/**
-	 * Jump to an address in the program.
-	 * @param to The address to jump to.
+	 * Jumps to an address in the program.
+	 * @param address The address to jump to.
 	 */
-	public jump(to: OpAddress): void {
-		assert(to > 0, "Parameter 'to' is out of bounds for program (under)");
-		assert(to < this.program!.data!.length, "Parameter 'to' is out of bounds for program (over)");
-		assert(isValid(to), "Parameter 'to' is out of range for OpAddress");
-		this.program_counter = to;
-	}
-  
-  /*
-	 * Jumps forwards to a relative address in the program.
-	 * @param by The number of instructions to jump.
-	 */
-	public jumpForwards(by: OpAddress): void {
-		assert(isValid(by), "Parameter 'by' is out of range for OpAddress");
-		this.jump(this.program_counter + by);
+	public jump(address: OpAddress): void {
+		assert(address >= 0, "Parameter 'address' is out of bounds for program (under)");
+		assert(address < this.program!.data!.length, "Parameter 'address' is out of bounds for program (over)");
+		assert(isValid(address), "Parameter 'address' is out of range for OpAddress");
+
+		// NOTE: If the VM is executing, we need to account for the fact that the PC will be
+		//       incremented after the instruction has finished executing.
+
+		this.program_counter = this._VM_executing ? address - 2 : address;
 	}
 
 	/**
-	 * Jumps backwards to a relative address in the program.
-	 * @param by The number of instructions to jump.
+	 * Jumps forwards by a specified number of opcodes.
+	 * Unlike {@link #jump jump}, this is a 2-byte relative jump.
+	 *
+	 * @param instructions The number of instructions to jump.
 	 */
-	public jumpBackwards(by: OpAddress): void {
-		assert(isValid(by), "Parameter 'by' is out of range for OpAddress");
-		this.jump(this.program_counter - by);
-  }
+	public hopForwards(instructions: OpAddress): void {
+		assert(isValid(instructions), "Parameter 'instructions' is out of range for OpAddress");
+		this.jump(this.program_counter + instructions * 2);
+	}
+
+	/**
+	 * Jumps backwards by a specified number of opcodes.
+	 * Unlike {@link #jump jump}, this is a 2-byte relative jump.
+	 *
+	 * @param instructions The number of instructions to jump.
+	 */
+	public hopBackwards(instructions: OpAddress): void {
+		assert(isValid(instructions), "Parameter 'instructions' is out of range for OpAddress");
+		this.jump(this.program_counter - instructions * 2);
+	}
 
 	/**
 	 * Resets the virtual machine.


### PR DESCRIPTION
## Changelog
- vm: Rename `jumpForwards` to `hopForwards`
- vm: Rename `jumpBackwards` to `hopBackwards`
- arch-chip: Change function calls from `jump*` to `hop*`

## Reasoning
```
These operations are designed to work on 16-bit aligned instructions,
and not individual bytes. A name change was needed to reflect this and
highlight the difference between 'jump', which operates on a raw,
unaligned memory address.
```

**Example:**
`hopForwards(2)` -> `jump(PC + 4)` // Skip the next instruction.