### PR TITLE
vm: Fix Timer (hopefully)

### DIFF
--- a/module/vm/src/Timer.ts
+++ b/module/vm/src/Timer.ts
@@ -41,7 +41,7 @@ export default abstract class Timer {
 	public constructor(cpuHz: number, timerHz: number) {
 		this.value = 0;
 		this.error = 0;
-		this.ratio = cpuHz / timerHz;
+		this.ratio = timerHz / cpuHz;
 	}
 
 	// -------------------------------------------------------------------------------------------------------------

--- a/module/vm/src/TimerAscending.ts
+++ b/module/vm/src/TimerAscending.ts
@@ -20,7 +20,8 @@ export default class TimerAscending extends Timer {
 	 */
 	public update() {
 		let updated = this.value + this.ratio + this.error;
+
 		this.value = updated | 0;
-		this.error = updated < 0 ? updated + this.value : updated - this.value;
+		this.error = updated - this.value;
 	}
 }

--- a/module/vm/src/TimerDescending.ts
+++ b/module/vm/src/TimerDescending.ts
@@ -19,8 +19,9 @@ export default class TimerDescending extends Timer {
 	 * @override
 	 */
 	public update() {
-		let updated = this.value - (this.ratio + this.error);
+		let updated = this.value - this.ratio + this.error;
+
 		this.value = updated | 0;
-		this.error = updated < 0 ? updated + this.value : updated - this.value;
+		this.error = updated - this.value;
 	}
 }

--- a/module/vm/test/TimerAscending.ts
+++ b/module/vm/test/TimerAscending.ts
@@ -1,0 +1,49 @@
+//! --------------------------------------------------------------------------------------------------------------------
+//! Copyright (C) 2019 Team Chipotle
+//! MIT License
+//! --------------------------------------------------------------------------------------------------------------------
+import TimerAscending from '../src/TimerAscending';
+// ---------------------------------------------------------------------------------------------------------------------
+
+describe('TimerAscending', () => {
+	it('constructor', () => {
+		let timer = new TimerAscending(10, 1);
+		expect((<any>timer).value).toEqual(0);
+		expect((<any>timer).error).toEqual(0);
+		expect((<any>timer).ratio).toEqual(0.1);
+
+		let timer2 = new TimerAscending(1, 10);
+		expect((<any>timer2).ratio).toEqual(10);
+	});
+
+	it('update (from 1)', () => {
+		let timer = new TimerAscending(10, 1);
+		timer.value = 1;
+
+		for (let i = 0; i < 0.9; i += 0.1) {
+			expect(timer.value).toEqual(1);
+			expect((<any>timer).error).toBeCloseTo(i, Number.EPSILON);
+			timer.update();
+		}
+
+		console.log(timer);
+		expect(timer.value).toEqual(2);
+		expect((<any>timer).error).toBeCloseTo(0, Number.EPSILON);
+	});
+
+	it('update (from -1)', () => {
+		let timer = new TimerAscending(10, 1);
+		timer.value = -1;
+
+		for (let i = 0; i < 9; i++) {
+			timer.update();
+			expect(timer.value).toEqual(0);
+			expect((<any>timer).error).toBeCloseTo(-(1 - i / 10), Number.EPSILON);
+		}
+
+		timer.update();
+		timer.update();
+		expect(timer.value).toEqual(0);
+		expect((<any>timer).error).toBeCloseTo(0, Number.EPSILON);
+	});
+});

--- a/module/vm/test/TimerDescending.ts
+++ b/module/vm/test/TimerDescending.ts
@@ -1,0 +1,48 @@
+//! --------------------------------------------------------------------------------------------------------------------
+//! Copyright (C) 2019 Team Chipotle
+//! MIT License
+//! --------------------------------------------------------------------------------------------------------------------
+import TimerDescending from '../src/TimerDescending';
+// ---------------------------------------------------------------------------------------------------------------------
+
+describe('TimerDescending', () => {
+	it('constructor', () => {
+		let timer = new TimerDescending(10, 1);
+		expect((<any>timer).value).toEqual(0);
+		expect((<any>timer).error).toEqual(0);
+		expect((<any>timer).ratio).toEqual(0.1);
+
+		let timer2 = new TimerDescending(1, 10);
+		expect((<any>timer2).ratio).toEqual(10);
+	});
+
+	it('update (from 1)', () => {
+		let timer = new TimerDescending(10, 1);
+		timer.value = 1;
+
+		for (let i = 0.9; i >= 0; i -= 0.1) {
+			timer.update();
+			expect(timer.value).toEqual(0);
+			expect((<any>timer).error).toBeCloseTo(i, Number.EPSILON);
+		}
+
+		timer.update();
+		timer.update();
+		expect(timer.value).toEqual(0);
+		expect((<any>timer).error).toBeCloseTo(0, Number.EPSILON);
+	});
+
+	it('update (from -1)', () => {
+		let timer = new TimerDescending(10, 1);
+		timer.value = -1;
+
+		for (let i = 0; i < 10; i++) {
+			expect(timer.value).toEqual(-1);
+			expect((<any>timer).error).toBeCloseTo(-(i / 10), Number.EPSILON);
+			timer.update();
+		}
+
+		expect(timer.value).toEqual(-2);
+		expect((<any>timer).error).toBeCloseTo(0, Number.EPSILON);
+	});
+});


### PR DESCRIPTION
## Changelog
- vm: Add tests for TimerAscending
- vm: Add tests for TimerDescending
- vm: Fix math for TimerAscending, TimerDescending, and Timer.

## Notes
These things might prove to be an issue later.
I hadn't initially considered the risks of floating point errors, but they have the potential to screw up the timings (e.g. program expects a `0`, but the timer class has `1` with an error of `0.99999999999`).

Hopefully we won't come across this as a real issue, but I'm noting it down here now.