### PR TITLE
ci: Add different build flags for dev and release, add Netlify build hook

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -100,7 +100,7 @@ jobs:
           command: mkdir -p target artifacts || true
       - run:
           name: Build
-          command: ./sct build {{ parameters.args }}
+          command: ./sct build << parameters.args >>
       - persist_to_workspace:
           root: *workspace_root
           paths:


### PR DESCRIPTION
If we trigger a release build on CircleCI, and it passes, it will tell Netlify to build the `master` branch.