### PR TITLE
chip-arch: Add register_index to snapshots

### DIFF
--- a/module/chip-arch/src/Chip.ts
+++ b/module/chip-arch/src/Chip.ts
@@ -381,6 +381,7 @@ class Chip extends Architecture<Chip> {
 		this.register_data.set(new Uint8Array(Decoder.string(Decoder.base64(<string>snapshot.register_data))));
 		this.register_sound = <number>snapshot.register_sound;
 		this.register_timer = <number>snapshot.register_timer;
+		this.register_index = <number>snapshot.register_index;
 		this.random.state = <number>snapshot.random;
 		this.stack.restore(snapshot.stack);
 		this.display.restore(<string>snapshot.display);
@@ -394,6 +395,7 @@ class Chip extends Architecture<Chip> {
 			register_data: Encoder.base64(Encoder.string(this.register_data)),
 			register_sound: this.register_sound,
 			register_timer: this.register_timer,
+			register_index: this.register_index,
 			stack: this.stack.snapshot(),
 			display: this.display.snapshot(),
 			random: this.random.state

--- a/module/vm/src/VMSnapshot.ts
+++ b/module/vm/src/VMSnapshot.ts
@@ -34,7 +34,7 @@ interface VMSnapshot {
 }
 
 namespace VMSnapshot {
-	export const VERSION = 2;
+	export const VERSION = 3;
 }
 
 // ---------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
That explains why some snapshots were broken...